### PR TITLE
Update prefixes from ead_ to artpulse_

### DIFF
--- a/assets/js/advanced-taxonomy-filter-block.js
+++ b/assets/js/advanced-taxonomy-filter-block.js
@@ -9,7 +9,7 @@ registerBlockType('artpulse/advanced-taxonomy-filter', {
     icon: 'filter',
     category: 'widgets',
     attributes: {
-        postType: { type: 'string', default: 'ead_artist' },
+        postType: { type: 'string', default: 'artpulse_artist' },
         taxonomy: { type: 'string', default: 'artist_specialty' },
     },
 
@@ -29,7 +29,7 @@ registerBlockType('artpulse/advanced-taxonomy-filter', {
         useEffect(() => {
             apiFetch({ path: '/wp/v2/types' }).then(types => {
                 const cpts = Object.entries(types)
-                    .filter(([key, val]) => val.rest_base && key.startsWith('ead_'))
+                    .filter(([key, val]) => val.rest_base && key.startsWith('artpulse_'))
                     .map(([key]) => key);
                 setAvailablePostTypes(cpts);
             });

--- a/assets/js/ajax-filter-block.js
+++ b/assets/js/ajax-filter-block.js
@@ -9,7 +9,7 @@ registerBlockType('artpulse/ajax-filter', {
     category: 'widgets',
 
     attributes: {
-        postType: { type: 'string', default: 'ead_artist' },
+        postType: { type: 'string', default: 'artpulse_artist' },
         taxonomy: { type: 'string', default: 'artist_specialty' },
     },
 
@@ -20,7 +20,7 @@ registerBlockType('artpulse/ajax-filter', {
 
         useEffect(() => {
             apiFetch({ path: '/wp/v2/types' }).then(types => {
-                const filtered = Object.entries(types).filter(([key]) => key.startsWith('ead_'));
+                const filtered = Object.entries(types).filter(([key]) => key.startsWith('artpulse_'));
                 setPostTypes(filtered.map(([key]) => ({ label: key, value: key })));
             });
         }, []);

--- a/assets/js/filtered-list-shortcode-block.js
+++ b/assets/js/filtered-list-shortcode-block.js
@@ -5,10 +5,10 @@ const { useState, useEffect } = wp.element;
 const { apiFetch } = wp;
 
 const postTypeOptions = [
-    { label: 'Artist', value: 'ead_artist' },
-    { label: 'Artwork', value: 'ead_artwork' },
-    { label: 'Event', value: 'ead_event' },
-    { label: 'Organization', value: 'ead_organization' },
+    { label: 'Artist', value: 'artpulse_artist' },
+    { label: 'Artwork', value: 'artpulse_artwork' },
+    { label: 'Event', value: 'artpulse_event' },
+    { label: 'Organization', value: 'artpulse_org' },
 ];
 
 registerBlockType('artpulse/filtered-list-shortcode', {
@@ -16,7 +16,7 @@ registerBlockType('artpulse/filtered-list-shortcode', {
     icon: 'list-view',
     category: 'widgets',
     attributes: {
-        postType: { type: 'string', default: 'ead_artist' },
+        postType: { type: 'string', default: 'artpulse_artist' },
         taxonomy: { type: 'string', default: 'artist_specialty' },
         terms: { type: 'string', default: '' },
         postsPerPage: { type: 'number', default: 5 },

--- a/assets/js/sidebar-taxonomies.js
+++ b/assets/js/sidebar-taxonomies.js
@@ -6,16 +6,16 @@ const { compose } = wp.compose;
 const { Fragment } = wp.element;
 
 const taxonomiesConfig = {
-    ead_artist: [
+    artpulse_artist: [
         { slug: 'artist_specialty', label: 'Artist Specialties' },
     ],
-    ead_artwork: [
+    artpulse_artwork: [
         { slug: 'artwork_style', label: 'Artwork Styles' },
     ],
-    ead_event: [
+    artpulse_event: [
         { slug: 'event_type', label: 'Event Types' },
     ],
-    ead_organization: [
+    artpulse_org: [
         { slug: 'organization_category', label: 'Organization Categories' },
     ],
 };

--- a/assets/js/taxonomy-filter-block.js
+++ b/assets/js/taxonomy-filter-block.js
@@ -9,7 +9,7 @@ registerBlockType('artpulse/taxonomy-filter', {
     icon: 'filter',
     category: 'widgets',
     attributes: {
-        postType: { type: 'string', default: 'ead_artist' },
+        postType: { type: 'string', default: 'artpulse_artist' },
         taxonomy: { type: 'string', default: 'artist_specialty' },
         terms: { type: 'array', default: [] },
     },
@@ -25,7 +25,7 @@ registerBlockType('artpulse/taxonomy-filter', {
             // Get all custom post types with REST support
             apiFetch({ path: '/wp/v2/types' }).then((types) => {
                 const cpts = Object.entries(types)
-                    .filter(([key, val]) => val.rest_base && key.startsWith('ead_'))
+                    .filter(([key, val]) => val.rest_base && key.startsWith('artpulse_'))
                     .map(([key]) => key);
                 setAvailablePostTypes(cpts);
             });

--- a/src/Admin/AdminColumnsArtist.php
+++ b/src/Admin/AdminColumnsArtist.php
@@ -4,9 +4,9 @@ namespace ArtPulse\Admin;
 class AdminColumnsArtist {
 
     public static function register() {
-        add_filter('manage_ead_artist_posts_columns', [self::class, 'custom_columns']);
-        add_action('manage_ead_artist_posts_custom_column', [self::class, 'render_columns'], 10, 2);
-        add_filter('manage_edit-ead_artist_sortable_columns', [self::class, 'sortable_columns']);
+        add_filter('manage_artpulse_artist_posts_columns', [self::class, 'custom_columns']);
+        add_action('manage_artpulse_artist_posts_custom_column', [self::class, 'render_columns'], 10, 2);
+        add_filter('manage_edit-artpulse_artist_sortable_columns', [self::class, 'sortable_columns']);
         add_action('quick_edit_custom_box', [self::class, 'quick_edit'], 10, 2);
         add_action('save_post', [self::class, 'save_quick_edit']);
     }
@@ -51,7 +51,7 @@ class AdminColumnsArtist {
     }
 
     public static function quick_edit($column_name, $post_type) {
-        if ($post_type !== 'ead_artist' || $column_name !== 'artist_featured') return;
+        if ($post_type !== 'artpulse_artist' || $column_name !== 'artist_featured') return;
         echo '<fieldset class="inline-edit-col-left">
                 <div class="inline-edit-col">
                     <label class="alignleft">
@@ -63,9 +63,9 @@ class AdminColumnsArtist {
     }
 
     public static function save_quick_edit($post_id) {
-        if (!isset($_POST['artist_featured']) && get_post_type($post_id) === 'ead_artist') {
+        if (!isset($_POST['artist_featured']) && get_post_type($post_id) === 'artpulse_artist') {
             update_post_meta($post_id, 'artist_featured', '0');
-        } elseif (get_post_type($post_id) === 'ead_artist') {
+        } elseif (get_post_type($post_id) === 'artpulse_artist') {
             update_post_meta($post_id, 'artist_featured', '1');
         }
     }

--- a/src/Admin/AdminColumnsArtwork.php
+++ b/src/Admin/AdminColumnsArtwork.php
@@ -4,9 +4,9 @@ namespace ArtPulse\Admin;
 class AdminColumnsArtwork {
 
     public static function register() {
-        add_filter('manage_ead_artwork_posts_columns', [self::class, 'add_columns']);
-        add_action('manage_ead_artwork_posts_custom_column', [self::class, 'render_column'], 10, 2);
-        add_filter('manage_edit-ead_artwork_sortable_columns', [self::class, 'sortable_columns']);
+        add_filter('manage_artpulse_artwork_posts_columns', [self::class, 'add_columns']);
+        add_action('manage_artpulse_artwork_posts_custom_column', [self::class, 'render_column'], 10, 2);
+        add_filter('manage_edit-artpulse_artwork_sortable_columns', [self::class, 'sortable_columns']);
         add_action('quick_edit_custom_box', [self::class, 'quick_edit_box'], 10, 2);
         add_action('save_post', [self::class, 'save_quick_edit'], 10, 2);
     }
@@ -55,7 +55,7 @@ class AdminColumnsArtwork {
     }
 
     public static function quick_edit_box($column, $post_type) {
-        if ($post_type !== 'ead_artwork' || $column !== 'artwork_featured') return;
+        if ($post_type !== 'artpulse_artwork' || $column !== 'artwork_featured') return;
         ?>
         <fieldset class="inline-edit-col-left">
             <div class="inline-edit-col">
@@ -69,7 +69,7 @@ class AdminColumnsArtwork {
     }
 
     public static function save_quick_edit($post_id, $post) {
-        if ($post->post_type !== 'ead_artwork') return;
+        if ($post->post_type !== 'artpulse_artwork') return;
 
         if (isset($_POST['artwork_featured'])) {
             update_post_meta($post_id, 'artwork_featured', '1');

--- a/src/Admin/AdminColumnsEvent.php
+++ b/src/Admin/AdminColumnsEvent.php
@@ -4,9 +4,9 @@ namespace ArtPulse\Admin;
 class AdminColumnsEvent {
 
     public static function register() {
-        add_filter('manage_ead_event_posts_columns', [self::class, 'add_columns']);
-        add_action('manage_ead_event_posts_custom_column', [self::class, 'render_columns'], 10, 2);
-        add_filter('manage_edit-ead_event_sortable_columns', [self::class, 'make_sortable']);
+        add_filter('manage_artpulse_event_posts_columns', [self::class, 'add_columns']);
+        add_action('manage_artpulse_event_posts_custom_column', [self::class, 'render_columns'], 10, 2);
+        add_filter('manage_edit-artpulse_event_sortable_columns', [self::class, 'make_sortable']);
     }
 
     public static function add_columns($columns) {

--- a/src/Admin/AdminColumnsTaxonomies.php
+++ b/src/Admin/AdminColumnsTaxonomies.php
@@ -5,26 +5,26 @@ class AdminColumnsTaxonomies {
 
     public static function register() {
         // Artist specialties
-        add_filter('manage_edit-ead_artist_columns', [self::class, 'artist_columns']);
-        add_filter('manage_edit-ead_artist_sortable_columns', [self::class, 'artist_sortable_columns']);
+        add_filter('manage_edit-artpulse_artist_columns', [self::class, 'artist_columns']);
+        add_filter('manage_edit-artpulse_artist_sortable_columns', [self::class, 'artist_sortable_columns']);
 
         // Artwork styles
-        add_filter('manage_edit-ead_artwork_columns', [self::class, 'artwork_columns']);
-        add_filter('manage_edit-ead_artwork_sortable_columns', [self::class, 'artwork_sortable_columns']);
+        add_filter('manage_edit-artpulse_artwork_columns', [self::class, 'artwork_columns']);
+        add_filter('manage_edit-artpulse_artwork_sortable_columns', [self::class, 'artwork_sortable_columns']);
 
         // Event types
-        add_filter('manage_edit-ead_event_columns', [self::class, 'event_columns']);
-        add_filter('manage_edit-ead_event_sortable_columns', [self::class, 'event_sortable_columns']);
+        add_filter('manage_edit-artpulse_event_columns', [self::class, 'event_columns']);
+        add_filter('manage_edit-artpulse_event_sortable_columns', [self::class, 'event_sortable_columns']);
 
         // Organization categories
-        add_filter('manage_edit-ead_organization_columns', [self::class, 'org_columns']);
-        add_filter('manage_edit-ead_organization_sortable_columns', [self::class, 'org_sortable_columns']);
+        add_filter('manage_edit-artpulse_org_columns', [self::class, 'org_columns']);
+        add_filter('manage_edit-artpulse_org_sortable_columns', [self::class, 'org_sortable_columns']);
 
         // Render taxonomy columns
-        add_action('manage_ead_artist_posts_custom_column', [self::class, 'render_artist_columns'], 10, 2);
-        add_action('manage_ead_artwork_posts_custom_column', [self::class, 'render_artwork_columns'], 10, 2);
-        add_action('manage_ead_event_posts_custom_column', [self::class, 'render_event_columns'], 10, 2);
-        add_action('manage_ead_organization_posts_custom_column', [self::class, 'render_org_columns'], 10, 2);
+        add_action('manage_artpulse_artist_posts_custom_column', [self::class, 'render_artist_columns'], 10, 2);
+        add_action('manage_artpulse_artwork_posts_custom_column', [self::class, 'render_artwork_columns'], 10, 2);
+        add_action('manage_artpulse_event_posts_custom_column', [self::class, 'render_event_columns'], 10, 2);
+        add_action('manage_artpulse_org_posts_custom_column', [self::class, 'render_org_columns'], 10, 2);
 
         // Sort query modification
         add_action('pre_get_posts', [self::class, 'taxonomy_sort_order']);
@@ -114,10 +114,10 @@ class AdminColumnsTaxonomies {
 
         $orderby = $query->get('orderby');
         $taxonomies = [
-            'artist_specialty' => 'ead_artist',
-            'artwork_style' => 'ead_artwork',
-            'event_type' => 'ead_event',
-            'organization_category' => 'ead_organization',
+            'artist_specialty' => 'artpulse_artist',
+            'artwork_style' => 'artpulse_artwork',
+            'event_type' => 'artpulse_event',
+            'organization_category' => 'artpulse_org',
         ];
 
         if (!isset($taxonomies[$orderby])) {

--- a/src/Admin/AdminListColumns.php
+++ b/src/Admin/AdminListColumns.php
@@ -5,14 +5,14 @@ class AdminListColumns
 {
     public static function register()
     {
-        add_filter('manage_ead_artist_posts_columns', [self::class, 'artist_columns']);
-        add_action('manage_ead_artist_posts_custom_column', [self::class, 'render_artist_columns'], 10, 2);
+        add_filter('manage_artpulse_artist_posts_columns', [self::class, 'artist_columns']);
+        add_action('manage_artpulse_artist_posts_custom_column', [self::class, 'render_artist_columns'], 10, 2);
 
-        add_filter('manage_ead_artwork_posts_columns', [self::class, 'artwork_columns']);
-        add_action('manage_ead_artwork_posts_custom_column', [self::class, 'render_artwork_columns'], 10, 2);
+        add_filter('manage_artpulse_artwork_posts_columns', [self::class, 'artwork_columns']);
+        add_action('manage_artpulse_artwork_posts_custom_column', [self::class, 'render_artwork_columns'], 10, 2);
 
-        add_filter('manage_ead_event_posts_columns', [self::class, 'event_columns']);
-        add_action('manage_ead_event_posts_custom_column', [self::class, 'render_event_columns'], 10, 2);
+        add_filter('manage_artpulse_event_posts_columns', [self::class, 'event_columns']);
+        add_action('manage_artpulse_event_posts_custom_column', [self::class, 'render_event_columns'], 10, 2);
     }
 
     // --- Artists ---

--- a/src/Admin/AdminListSorting.php
+++ b/src/Admin/AdminListSorting.php
@@ -6,23 +6,23 @@ class AdminListSorting {
         add_action('pre_get_posts', [self::class, 'sort_admin_columns']);
 
         // Make columns sortable
-        add_filter('manage_edit-ead_artist_sortable_columns', function ($columns) {
+        add_filter('manage_edit-artpulse_artist_sortable_columns', function ($columns) {
             $columns['artist_featured'] = 'artist_featured';
             return $columns;
         });
 
-        add_filter('manage_edit-ead_artwork_sortable_columns', function ($columns) {
+        add_filter('manage_edit-artpulse_artwork_sortable_columns', function ($columns) {
             $columns['artwork_featured'] = 'artwork_featured';
             return $columns;
         });
 
-        add_filter('manage_edit-ead_event_sortable_columns', function ($columns) {
+        add_filter('manage_edit-artpulse_event_sortable_columns', function ($columns) {
             $columns['event_featured'] = 'event_featured';
             return $columns;
         });
 
-        add_filter('manage_edit-ead_organization_sortable_columns', function ($columns) {
-            $columns['ead_org_type'] = 'ead_org_type';
+        add_filter('manage_edit-artpulse_org_sortable_columns', function ($columns) {
+            $columns['artpulse_org_type'] = 'artpulse_org_type';
             return $columns;
         });
     }
@@ -36,7 +36,7 @@ class AdminListSorting {
             'artist_featured',
             'artwork_featured',
             'event_featured',
-            'ead_org_type',
+            'artpulse_org_type',
         ];
 
         if (in_array($orderby, $sortable_meta_keys)) {

--- a/src/Admin/MetaBoxesAddress.php
+++ b/src/Admin/MetaBoxesAddress.php
@@ -11,7 +11,7 @@ class MetaBoxesAddress {
         foreach ($post_types as $post_type) {
             add_action("add_meta_boxes_{$post_type}", function($post) use ($post_type) {
                 add_meta_box(
-                    'ead_address_' . $post_type,
+                    'artpulse_address_' . $post_type,
                     __('Address', 'artpulse-management'),
                     [self::class, 'render_address_meta_box'],
                     $post_type,
@@ -27,7 +27,7 @@ class MetaBoxesAddress {
     }
 
     public static function render_address_meta_box($post) {
-        wp_nonce_field('ead_address_meta_nonce', 'ead_address_meta_nonce_field');
+        wp_nonce_field('artpulse_address_meta_nonce', 'artpulse_address_meta_nonce_field');
 
         $fields = self::get_address_meta_fields();
 
@@ -42,7 +42,7 @@ class MetaBoxesAddress {
     }
 
     public static function save_address_meta($post_id, $post) {
-        if (!isset($_POST['ead_address_meta_nonce_field']) || !wp_verify_nonce($_POST['ead_address_meta_nonce_field'], 'ead_address_meta_nonce')) {
+        if (!isset($_POST['artpulse_address_meta_nonce_field']) || !wp_verify_nonce($_POST['artpulse_address_meta_nonce_field'], 'artpulse_address_meta_nonce')) {
             return;
         }
 

--- a/src/Admin/MetaBoxesArtist.php
+++ b/src/Admin/MetaBoxesArtist.php
@@ -5,7 +5,7 @@ class MetaBoxesArtist {
 
     public static function register() {
         add_action('add_meta_boxes', [self::class, 'add_artist_meta_boxes']);
-        add_action('save_post_ead_artist', [self::class, 'save_artist_meta'], 10, 2);
+        add_action('save_post_artpulse_artist', [self::class, 'save_artist_meta'], 10, 2);
         add_action('rest_api_init', [self::class, 'register_rest_fields']);
         add_action('restrict_manage_posts', [self::class, 'add_admin_filters']);
         add_filter('pre_get_posts', [self::class, 'filter_admin_query']);
@@ -13,17 +13,17 @@ class MetaBoxesArtist {
 
     public static function add_artist_meta_boxes() {
         add_meta_box(
-            'ead_artist_details',
+            'artpulse_artist_details',
             __('Artist Details', 'artpulse-management'),
             [self::class, 'render_artist_details'],
-            'ead_artist',
+            'artpulse_artist',
             'normal',
             'high'
         );
     }
 
     public static function render_artist_details($post) {
-        wp_nonce_field('ead_artist_meta_nonce', 'ead_artist_meta_nonce_field');
+        wp_nonce_field('artpulse_artist_meta_nonce', 'artpulse_artist_meta_nonce_field');
 
         $fields = self::get_registered_artist_meta_fields();
 
@@ -55,12 +55,12 @@ class MetaBoxesArtist {
     }
 
     public static function save_artist_meta($post_id, $post) {
-        if (!isset($_POST['ead_artist_meta_nonce_field']) || !wp_verify_nonce($_POST['ead_artist_meta_nonce_field'], 'ead_artist_meta_nonce')) {
+        if (!isset($_POST['artpulse_artist_meta_nonce_field']) || !wp_verify_nonce($_POST['artpulse_artist_meta_nonce_field'], 'artpulse_artist_meta_nonce')) {
             return;
         }
 
         if (defined('DOING_AUTOSAVE') && DOING_AUTOSAVE) return;
-        if ($post->post_type !== 'ead_artist') return;
+        if ($post->post_type !== 'artpulse_artist') return;
 
         $fields = self::get_registered_artist_meta_fields();
         foreach ($fields as $field => $args) {
@@ -93,7 +93,7 @@ class MetaBoxesArtist {
 
     public static function register_rest_fields() {
         foreach (array_keys(self::get_registered_artist_meta_fields()) as $key) {
-            register_rest_field('ead_artist', $key, [
+            register_rest_field('artpulse_artist', $key, [
                 'get_callback' => function($object) use ($key) {
                     return get_post_meta($object['id'], $key, true);
                 },
@@ -106,7 +106,7 @@ class MetaBoxesArtist {
     }
 
     public static function add_admin_filters() {
-        if (get_current_screen()->post_type !== 'ead_artist') return;
+        if (get_current_screen()->post_type !== 'artpulse_artist') return;
         $selected = $_GET['artist_featured'] ?? '';
         echo '<select name="artist_featured">';
         echo '<option value="">' . __('Filter by Featured', 'artpulse-management') . '</option>';
@@ -116,7 +116,7 @@ class MetaBoxesArtist {
     }
 
     public static function filter_admin_query($query) {
-        if (!is_admin() || !$query->is_main_query() || $query->get('post_type') !== 'ead_artist') return;
+        if (!is_admin() || !$query->is_main_query() || $query->get('post_type') !== 'artpulse_artist') return;
         if (isset($_GET['artist_featured']) && $_GET['artist_featured'] !== '') {
             $query->set('meta_key', 'artist_featured');
             $query->set('meta_value', $_GET['artist_featured']);

--- a/src/Admin/MetaBoxesArtwork.php
+++ b/src/Admin/MetaBoxesArtwork.php
@@ -5,7 +5,7 @@ class MetaBoxesArtwork {
 
     public static function register() {
         add_action('add_meta_boxes', [self::class, 'add_artwork_meta_boxes']);
-        add_action('save_post_ead_artwork', [self::class, 'save_artwork_meta'], 10, 2);
+        add_action('save_post_artpulse_artwork', [self::class, 'save_artwork_meta'], 10, 2);
         add_action('rest_api_init', [self::class, 'register_rest_fields']);
         add_action('restrict_manage_posts', [self::class, 'add_admin_filters']);
         add_filter('pre_get_posts', [self::class, 'filter_artworks_admin_query']);
@@ -13,17 +13,17 @@ class MetaBoxesArtwork {
 
     public static function add_artwork_meta_boxes() {
         add_meta_box(
-            'ead_artwork_details',
+            'artpulse_artwork_details',
             __('Artwork Details', 'artpulse-management'),
             [self::class, 'render_artwork_details'],
-            'ead_artwork',
+            'artpulse_artwork',
             'normal',
             'high'
         );
     }
 
     public static function render_artwork_details($post) {
-        wp_nonce_field('ead_artwork_meta_nonce', 'ead_artwork_meta_nonce_field');
+        wp_nonce_field('artpulse_artwork_meta_nonce', 'artpulse_artwork_meta_nonce_field');
 
         $fields = self::get_registered_artwork_meta_fields();
 
@@ -55,12 +55,12 @@ class MetaBoxesArtwork {
     }
 
     public static function save_artwork_meta($post_id, $post) {
-        if (!isset($_POST['ead_artwork_meta_nonce_field']) || !wp_verify_nonce($_POST['ead_artwork_meta_nonce_field'], 'ead_artwork_meta_nonce')) {
+        if (!isset($_POST['artpulse_artwork_meta_nonce_field']) || !wp_verify_nonce($_POST['artpulse_artwork_meta_nonce_field'], 'artpulse_artwork_meta_nonce')) {
             return;
         }
 
         if (defined('DOING_AUTOSAVE') && DOING_AUTOSAVE) return;
-        if ($post->post_type !== 'ead_artwork') return;
+        if ($post->post_type !== 'artpulse_artwork') return;
 
         $fields = array_keys(self::get_registered_artwork_meta_fields());
         foreach ($fields as $field) {
@@ -86,7 +86,7 @@ class MetaBoxesArtwork {
 
     public static function register_rest_fields() {
         foreach (self::get_registered_artwork_meta_fields() as $field => $args) {
-            register_rest_field('ead_artwork', $field, [
+            register_rest_field('artpulse_artwork', $field, [
                 'get_callback' => function($object) use ($field) {
                     return get_post_meta($object['id'], $field, true);
                 },
@@ -102,7 +102,7 @@ class MetaBoxesArtwork {
     }
 
     public static function add_admin_filters() {
-        if (get_post_type() !== 'ead_artwork') return;
+        if (get_post_type() !== 'artpulse_artwork') return;
 
         $selected = $_GET['artwork_featured'] ?? '';
         echo '<select name="artwork_featured">
@@ -113,7 +113,7 @@ class MetaBoxesArtwork {
     }
 
     public static function filter_artworks_admin_query($query) {
-        if (!is_admin() || !$query->is_main_query() || $query->get('post_type') !== 'ead_artwork') return;
+        if (!is_admin() || !$query->is_main_query() || $query->get('post_type') !== 'artpulse_artwork') return;
 
         if (isset($_GET['artwork_featured']) && $_GET['artwork_featured'] !== '') {
             $query->set('meta_key', 'artwork_featured');

--- a/src/Admin/MetaBoxesEvent.php
+++ b/src/Admin/MetaBoxesEvent.php
@@ -5,7 +5,7 @@ class MetaBoxesEvent {
 
     public static function register() {
         add_action('add_meta_boxes', [self::class, 'add_event_meta_boxes']);
-        add_action('save_post_ead_event', [self::class, 'save_event_meta'], 10, 2);
+        add_action('save_post_artpulse_event', [self::class, 'save_event_meta'], 10, 2);
         add_action('rest_api_init', [self::class, 'register_rest_fields']);
         add_action('restrict_manage_posts', [self::class, 'add_admin_filters']);
         add_filter('pre_get_posts', [self::class, 'filter_admin_query']);
@@ -13,17 +13,17 @@ class MetaBoxesEvent {
 
     public static function add_event_meta_boxes() {
         add_meta_box(
-            'ead_event_details',
+            'artpulse_event_details',
             __('Event Details', 'artpulse-management'),
             [self::class, 'render_event_details'],
-            'ead_event',
+            'artpulse_event',
             'normal',
             'high'
         );
     }
 
     public static function render_event_details($post) {
-        wp_nonce_field('ead_event_meta_nonce', 'ead_event_meta_nonce_field');
+        wp_nonce_field('artpulse_event_meta_nonce', 'artpulse_event_meta_nonce_field');
 
         $fields = self::get_registered_event_meta_fields();
 
@@ -54,9 +54,9 @@ class MetaBoxesEvent {
     }
 
     public static function save_event_meta($post_id, $post) {
-        if (!isset($_POST['ead_event_meta_nonce_field']) || !wp_verify_nonce($_POST['ead_event_meta_nonce_field'], 'ead_event_meta_nonce')) return;
+        if (!isset($_POST['artpulse_event_meta_nonce_field']) || !wp_verify_nonce($_POST['artpulse_event_meta_nonce_field'], 'artpulse_event_meta_nonce')) return;
         if (defined('DOING_AUTOSAVE') && DOING_AUTOSAVE) return;
-        if ($post->post_type !== 'ead_event') return;
+        if ($post->post_type !== 'artpulse_event') return;
 
         $fields = self::get_registered_event_meta_fields();
         foreach ($fields as $field => $args) {
@@ -89,7 +89,7 @@ class MetaBoxesEvent {
 
     public static function register_rest_fields() {
         foreach (self::get_registered_event_meta_fields() as $field => $args) {
-            register_rest_field('ead_event', $field, [
+            register_rest_field('artpulse_event', $field, [
                 'get_callback'    => fn($object) => get_post_meta($object['id'], $field, true),
                 'update_callback' => fn($value, $object) => update_post_meta($object->ID, $field, sanitize_text_field($value)),
                 'schema'          => ['type' => 'string'],
@@ -98,7 +98,7 @@ class MetaBoxesEvent {
     }
 
     public static function add_admin_filters() {
-        if (get_current_screen()->post_type !== 'ead_event') return;
+        if (get_current_screen()->post_type !== 'artpulse_event') return;
         $selected = $_GET['event_featured'] ?? '';
         echo '<select name="event_featured">
             <option value="">' . __('Filter by Featured', 'artpulse-management') . '</option>
@@ -108,7 +108,7 @@ class MetaBoxesEvent {
     }
 
     public static function filter_admin_query($query) {
-        if (!is_admin() || !$query->is_main_query() || $query->get('post_type') !== 'ead_event') return;
+        if (!is_admin() || !$query->is_main_query() || $query->get('post_type') !== 'artpulse_event') return;
 
         if (isset($_GET['event_featured']) && $_GET['event_featured'] !== '') {
             $query->set('meta_key', 'event_featured');

--- a/src/Admin/MetaBoxesRelationship.php
+++ b/src/Admin/MetaBoxesRelationship.php
@@ -8,45 +8,45 @@ class MetaBoxesRelationship
         [
             'id'           => 'ap_artist_artworks',
             'title'        => 'Associated Artworks',
-            'screen'       => 'ead_artist',
+            'screen'       => 'artpulse_artist',
             'meta_key'     => '_ap_artist_artworks',
-            'related_type' => 'ead_artwork',
+            'related_type' => 'artpulse_artwork',
             'multiple'     => true,
             'description'  => 'Select artworks related to this artist.',
         ],
         [
             'id'           => 'ap_event_artworks',
             'title'        => 'Featured Artworks',
-            'screen'       => 'ead_event',
+            'screen'       => 'artpulse_event',
             'meta_key'     => '_ap_event_artworks',
-            'related_type' => 'ead_artwork',
+            'related_type' => 'artpulse_artwork',
             'multiple'     => true,
             'description'  => 'Select artworks featured in this event.',
         ],
         [
             'id'           => 'ap_event_organizations',
             'title'        => 'Participating Organizations',
-            'screen'       => 'ead_event',
+            'screen'       => 'artpulse_event',
             'meta_key'     => '_ap_event_organizations',
-            'related_type' => 'ead_organization',
+            'related_type' => 'artpulse_org',
             'multiple'     => true,
             'description'  => 'Select organizations participating in this event.',
         ],
         [
             'id'           => 'ap_artwork_artist',
             'title'        => 'Artwork Artist',
-            'screen'       => 'ead_artwork',
+            'screen'       => 'artpulse_artwork',
             'meta_key'     => '_ap_artwork_artist',
-            'related_type' => 'ead_artist',
+            'related_type' => 'artpulse_artist',
             'multiple'     => false,
             'description'  => 'Select the artist for this artwork.',
         ],
         [
             'id'           => 'ap_org_artists',
             'title'        => 'Associated Artists',
-            'screen'       => 'ead_organization',
+            'screen'       => 'artpulse_org',
             'meta_key'     => '_ap_org_artists',
-            'related_type' => 'ead_artist',
+            'related_type' => 'artpulse_artist',
             'multiple'     => true,
             'description'  => 'Select artists associated with this organization.',
         ],
@@ -172,7 +172,7 @@ class MetaBoxesRelationship
         check_ajax_referer('ap_ajax_nonce', 'nonce');
 
         $term = sanitize_text_field($_GET['q'] ?? '');
-        $post_type = sanitize_text_field($_GET['post_type'] ?? 'ead_artwork');
+        $post_type = sanitize_text_field($_GET['post_type'] ?? 'artpulse_artwork');
 
         $args = [
             'post_type'      => $post_type,

--- a/src/Ajax/FrontendFilterHandler.php
+++ b/src/Ajax/FrontendFilterHandler.php
@@ -27,7 +27,7 @@ class FrontendFilterHandler
         }
 
         $args = [
-            'post_type'      => 'ead_artist',  // Adjust post type as needed
+            'post_type'      => 'artpulse_artist',  // Adjust post type as needed
             'post_status'    => 'publish',
             'posts_per_page' => $per_page,
             'paged'          => $page,

--- a/src/Blocks/AdvancedTaxonomyFilterBlock.php
+++ b/src/Blocks/AdvancedTaxonomyFilterBlock.php
@@ -16,7 +16,7 @@ class AdvancedTaxonomyFilterBlock {
             'editor_script' => 'artpulse-advanced-taxonomy-filter-block',
             'render_callback' => [self::class, 'render_callback'],
             'attributes' => [
-                'postType' => ['type' => 'string', 'default' => 'ead_artist'],
+                'postType' => ['type' => 'string', 'default' => 'artpulse_artist'],
                 'taxonomy' => ['type' => 'string', 'default' => 'artist_specialty'],
             ],
         ]);

--- a/src/Blocks/AjaxFilterBlock.php
+++ b/src/Blocks/AjaxFilterBlock.php
@@ -17,7 +17,7 @@ class AjaxFilterBlock {
             'editor_script'   => 'artpulse-ajax-filter-block',
             'render_callback' => [self::class, 'render_callback'],
             'attributes' => [
-                'postType' => ['type' => 'string', 'default' => 'ead_artist'],
+                'postType' => ['type' => 'string', 'default' => 'artpulse_artist'],
                 'taxonomy' => ['type' => 'string', 'default' => 'artist_specialty'],
             ],
         ]);

--- a/src/Blocks/FilteredListShortcodeBlock.php
+++ b/src/Blocks/FilteredListShortcodeBlock.php
@@ -16,7 +16,7 @@ class FilteredListShortcodeBlock {
             'editor_script' => 'artpulse-filtered-list-shortcode-block',
             'render_callback' => [self::class, 'render_callback'],
             'attributes' => [
-                'postType' => ['type' => 'string', 'default' => 'ead_artist'],
+                'postType' => ['type' => 'string', 'default' => 'artpulse_artist'],
                 'taxonomy' => ['type' => 'string', 'default' => 'artist_specialty'],
                 'terms' => ['type' => 'string', 'default' => ''],
                 'postsPerPage' => ['type' => 'number', 'default' => 5],
@@ -33,7 +33,7 @@ class FilteredListShortcodeBlock {
 
     public static function render_callback($attributes) {
         $atts = [
-            'post_type' => $attributes['postType'] ?? 'ead_artist',
+            'post_type' => $attributes['postType'] ?? 'artpulse_artist',
             'taxonomy' => $attributes['taxonomy'] ?? 'artist_specialty',
             'terms' => $attributes['terms'] ?? '',
             'posts_per_page' => $attributes['postsPerPage'] ?? 5,

--- a/src/Blocks/RelatedItemsSelectorBlock.php
+++ b/src/Blocks/RelatedItemsSelectorBlock.php
@@ -26,7 +26,7 @@ class RelatedItemsSelectorBlock
         // Example: Register post meta fields with REST API enabled
 
         // Meta for multiple related artworks for artists (array)
-        register_post_meta('ead_artist', '_ap_artist_artworks', [
+        register_post_meta('artpulse_artist', '_ap_artist_artworks', [
             'show_in_rest' => true,
             'single'       => false,
             'type'         => 'array',
@@ -37,7 +37,7 @@ class RelatedItemsSelectorBlock
         ]);
 
         // Meta for single related artist for artwork (integer)
-        register_post_meta('ead_artwork', '_ap_artwork_artist', [
+        register_post_meta('artpulse_artwork', '_ap_artwork_artist', [
             'show_in_rest' => true,
             'single'       => true,
             'type'         => 'integer',
@@ -52,7 +52,7 @@ class RelatedItemsSelectorBlock
             'attributes'    => [
                 'postType' => [
                     'type' => 'string',
-                    'default' => 'ead_artist',
+                    'default' => 'artpulse_artist',
                 ],
                 'metaKey' => [
                     'type' => 'string',

--- a/src/Blocks/TaxonomyFilterBlock.php
+++ b/src/Blocks/TaxonomyFilterBlock.php
@@ -16,7 +16,7 @@ class TaxonomyFilterBlock {
             'editor_script' => 'artpulse-taxonomy-filter-block',
             'render_callback' => [self::class, 'render_callback'],
             'attributes' => [
-                'postType' => ['type' => 'string', 'default' => 'ead_artist'],
+                'postType' => ['type' => 'string', 'default' => 'artpulse_artist'],
                 'taxonomy' => ['type' => 'string', 'default' => 'artist_specialty'],
                 'terms' => ['type' => 'array', 'default' => []],
             ],

--- a/src/Frontend/Shortcodes.php
+++ b/src/Frontend/Shortcodes.php
@@ -9,11 +9,11 @@ class Shortcodes {
 
     /**
      * Shortcode to render filtered CPT list by taxonomy terms.
-     * Usage example: [ap_filtered_list post_type="ead_artist" taxonomy="artist_specialty" terms="painting,sculpture" posts_per_page="5"]
+     * Usage example: [ap_filtered_list post_type="artpulse_artist" taxonomy="artist_specialty" terms="painting,sculpture" posts_per_page="5"]
      */
     public static function render_filtered_list($atts) {
         $atts = shortcode_atts([
-            'post_type' => 'ead_artist',
+            'post_type' => 'artpulse_artist',
             'taxonomy' => 'artist_specialty',
             'terms' => '',
             'posts_per_page' => 5,

--- a/src/Rest/RestRelationships.php
+++ b/src/Rest/RestRelationships.php
@@ -9,11 +9,11 @@ class RestRelationships
 
     public static function register_rest_fields() {
         $relationship_meta = [
-            '_ap_artist_artworks'     => 'ead_artist',
-            '_ap_event_artworks'      => 'ead_event',
-            '_ap_event_organizations' => 'ead_event',
-            '_ap_artwork_artist'      => 'ead_artwork',
-            '_ap_org_artists'         => 'ead_organization',
+            '_ap_artist_artworks'     => 'artpulse_artist',
+            '_ap_event_artworks'      => 'artpulse_event',
+            '_ap_event_organizations' => 'artpulse_event',
+            '_ap_artwork_artist'      => 'artpulse_artwork',
+            '_ap_org_artists'         => 'artpulse_org',
         ];
 
         foreach ($relationship_meta as $meta_key => $post_type) {

--- a/src/Rest/RestSortingSupport.php
+++ b/src/Rest/RestSortingSupport.php
@@ -3,7 +3,7 @@ namespace ArtPulse\Rest;
 
 class RestSortingSupport {
     public static function register() {
-        foreach (['ead_artist', 'ead_artwork', 'ead_event', 'ead_organization'] as $type) {
+        foreach (['artpulse_artist', 'artpulse_artwork', 'artpulse_event', 'artpulse_org'] as $type) {
             add_filter("rest_{$type}_collection_params", function ($params) {
                 $params['orderby']['enum'][] = 'meta_value';
                 $params['meta_key'] = [

--- a/src/Rest/TaxonomyRestFilters.php
+++ b/src/Rest/TaxonomyRestFilters.php
@@ -7,10 +7,10 @@ class TaxonomyRestFilters
     {
         add_action('rest_api_init', function () {
             $taxonomies = [
-                'ead_artist'       => 'artist_specialty',
-                'ead_artwork'      => 'artwork_style',
-                'ead_event'        => 'event_type',
-                'ead_organization' => 'organization_category',
+                'artpulse_artist'       => 'artist_specialty',
+                'artpulse_artwork'      => 'artwork_style',
+                'artpulse_event'        => 'event_type',
+                'artpulse_org' => 'organization_category',
             ];
 
             foreach ($taxonomies as $post_type => $taxonomy) {

--- a/src/Search/MetaFullTextSearch.php
+++ b/src/Search/MetaFullTextSearch.php
@@ -6,7 +6,7 @@ class MetaFullTextSearch {
         add_filter('posts_search', [self::class, 'posts_search_meta'], 10, 2);
 
         // REST API filters for meta search on all CPTs
-        foreach (['ead_artist', 'ead_artwork', 'ead_event', 'ead_organization'] as $post_type) {
+        foreach (['artpulse_artist', 'artpulse_artwork', 'artpulse_event', 'artpulse_org'] as $post_type) {
             add_filter("rest_{$post_type}_query", function($args, $request) use ($post_type) {
                 return self::rest_meta_search_filter($args, $request, $post_type);
             }, 10, 2);
@@ -22,7 +22,7 @@ class MetaFullTextSearch {
         }
 
         $post_type = $query->get('post_type');
-        if (!in_array($post_type, ['ead_artist', 'ead_artwork', 'ead_event', 'ead_organization'], true)) {
+        if (!in_array($post_type, ['artpulse_artist', 'artpulse_artwork', 'artpulse_event', 'artpulse_org'], true)) {
             return $search;
         }
 
@@ -77,14 +77,14 @@ class MetaFullTextSearch {
     // Define searchable meta keys per post type
     private static function get_meta_keys_for_post_type(string $post_type): array {
         switch ($post_type) {
-            case 'ead_artist':
+            case 'artpulse_artist':
                 return [
                     'artist_name',
                     'artist_bio',
                     'artist_email',
                     'artist_specialties',
                 ];
-            case 'ead_artwork':
+            case 'artpulse_artwork':
                 return [
                     'artwork_title',
                     'artwork_artist',
@@ -92,19 +92,19 @@ class MetaFullTextSearch {
                     'artwork_description',
                     'artwork_tags',
                 ];
-            case 'ead_event':
+            case 'artpulse_event':
                 return [
                     'venue_name',
                     'event_organizer_name',
                     'event_street_address',
                     'event_city',
                 ];
-            case 'ead_organization':
+            case 'artpulse_org':
                 return [
-                    'ead_org_type',
-                    'ead_org_description',
-                    'ead_org_city',
-                    'ead_org_website',
+                    'artpulse_org_type',
+                    'artpulse_org_description',
+                    'artpulse_org_city',
+                    'artpulse_org_website',
                 ];
             default:
                 return [];

--- a/src/Taxonomies/TaxonomiesRegistrar.php
+++ b/src/Taxonomies/TaxonomiesRegistrar.php
@@ -21,7 +21,7 @@ class TaxonomiesRegistrar {
             'new_item_name' => __('New Specialty Name', 'artpulse-management'),
             'menu_name' => __('Artist Specialties', 'artpulse-management'),
         ];
-        register_taxonomy('artist_specialty', 'ead_artist', [
+        register_taxonomy('artist_specialty', 'artpulse_artist', [
             'hierarchical' => true,
             'labels' => $labels,
             'show_ui' => true,
@@ -43,7 +43,7 @@ class TaxonomiesRegistrar {
             'new_item_name' => __('New Style Name', 'artpulse-management'),
             'menu_name' => __('Artwork Styles', 'artpulse-management'),
         ];
-        register_taxonomy('artwork_style', 'ead_artwork', [
+        register_taxonomy('artwork_style', 'artpulse_artwork', [
             'hierarchical' => true,
             'labels' => $labels,
             'show_ui' => true,
@@ -65,7 +65,7 @@ class TaxonomiesRegistrar {
             'new_item_name' => __('New Event Type Name', 'artpulse-management'),
             'menu_name' => __('Event Types', 'artpulse-management'),
         ];
-        register_taxonomy('event_type', 'ead_event', [
+        register_taxonomy('event_type', 'artpulse_event', [
             'hierarchical' => true,
             'labels' => $labels,
             'show_ui' => true,
@@ -87,7 +87,7 @@ class TaxonomiesRegistrar {
             'new_item_name' => __('New Organization Category Name', 'artpulse-management'),
             'menu_name' => __('Organization Categories', 'artpulse-management'),
         ];
-        register_taxonomy('organization_category', 'ead_organization', [
+        register_taxonomy('organization_category', 'artpulse_org', [
             'hierarchical' => true,
             'labels' => $labels,
             'show_ui' => true,


### PR DESCRIPTION
## Summary
- rename custom post type references from `ead_` to `artpulse_`
- adjust blocks and admin classes for new CPT names
- update AJAX filter handler to use new prefix

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_685123afe8f4832ebd911ee84b2f2de4