### PR TITLE
Guard display error settings behind WP_DEBUG

### DIFF
--- a/composer-setup.php
+++ b/composer-setup.php
@@ -20,7 +20,9 @@ process(is_array($argv) ? $argv : array());
  */
 function setupEnvironment()
 {
-    ini_set('display_errors', 1);
+    if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+        ini_set('display_errors', 1);
+    }
 
     if (extension_loaded('uopz') && !(ini_get('uopz.disable') || ini_get('uopz.exit'))) {
         // uopz works at opcode level and disables exit calls

--- a/src/Core/Plugin.php
+++ b/src/Core/Plugin.php
@@ -1,9 +1,11 @@
 <?php
 namespace ArtPulse\Core;
 
-ini_set('display_errors', 1);
-ini_set('display_startup_errors', 1);
-error_reporting(E_ALL);
+if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+    ini_set( 'display_errors', '1' );
+    ini_set( 'display_startup_errors', '1' );
+    error_reporting( E_ALL );
+}
 
 class Plugin
 {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -4,7 +4,9 @@
 require_once __DIR__ . '/../vendor/autoload.php';
 
 error_reporting(E_ALL);
-ini_set('display_errors', '1');
+if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+    ini_set('display_errors', '1');
+}
 
 // WP function stubs (safe to stub manually if not mocked in tests)
 if (!function_exists('get_option')) {


### PR DESCRIPTION
## Summary
- update `src/Core/Plugin.php` to only enable `display_errors` when `WP_DEBUG` is true
- guard composer setup's `display_errors` call
- only turn on `display_errors` in test bootstrap when `WP_DEBUG` is set

## Testing
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851268a5378832ebf68627d812ea28e