### PR TITLE
Add admin notice when plugin dependencies missing

### DIFF
--- a/artpulse-management.php
+++ b/artpulse-management.php
@@ -30,8 +30,22 @@ if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
 
 use ArtPulse\Core\Plugin;
 
-// Instantiate the plugin class
-$plugin = new Plugin();
+// Instantiate the plugin class if available; otherwise show admin notice
+if ( class_exists( Plugin::class ) ) {
+    $plugin = new Plugin();
+} else {
+    add_action(
+        'admin_notices',
+        static function () {
+            echo '<div class="notice notice-error"><p>';
+            esc_html_e(
+                'ArtPulse Management requires Composer dependencies. Please run "composer install".',
+                'artpulse'
+            );
+            echo '</p></div>';
+        }
+    );
+}
 
 
 // All other hooks (init, enqueue, REST API, etc.) are registered inside Plugin::__construct()


### PR DESCRIPTION
## Summary
- check for `ArtPulse\Core\Plugin` before instantiating
- show an admin notice prompting `composer install` when the class isn't available

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `vendor/bin/phpcs` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68512c9babcc832ebd9194b4ea753a17